### PR TITLE
fix ca_mgm module to not cut off authorityInfoAccess url value

### DIFF
--- a/package/yast2-ca-management.changes
+++ b/package/yast2-ca-management.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 21 16:03:16 CEST 2017 - mc@suse.de
+
+- fix ca_mgm module to not cut off authorityInfoAccess url value
+  (bsc#1051538)
+- version 3.1.10
+
+-------------------------------------------------------------------
 Tue Jun  7 09:18:07 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-ca-management.spec
+++ b/package/yast2-ca-management.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ca-management
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/ca-management/new_cert_read_write.rb
+++ b/src/include/ca-management/new_cert_read_write.rb
@@ -527,7 +527,7 @@ module Yast
       counter = 0
       Builtins.foreach(dummy) do |entry|
         entry = strip(entry)
-        valuelist = Builtins.splitstring(entry, ":")
+        valuelist = entry.split(":", 2)
         ident = strip(Ops.get_string(valuelist, 0, ""))
         value = strip(Ops.get_string(valuelist, 1, ""))
         if ident == "critical"


### PR DESCRIPTION
fix ca_mgm module to not cut off authorityInfoAccess url value (bsc#1051538)